### PR TITLE
Handle trunk branches tags in the middle of svn url

### DIFF
--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -17,8 +17,9 @@ function call()
 function do_clone()
 {
 	test -d .git_externals || return 1
-	module=`echo $remote_url|sed 's,\(.*\)\(/trunk\|/branch.*\|/tag.*\),\1,'`
-	branch=`echo $remote_url|sed 's,\(.*\)\(/trunk\|/branch.*\|/tag.*\),\2,'|sed 's,^/,,'`
+	module=`echo $remote_url|sed 's,\(.*\)\(/trunk.*\|/branch.*\|/tag.*\),\1,'`
+	branch=`echo $remote_url|sed 's,\(.*\)\(/trunk.*\|/branch.*\|/tag.*\),\2,'|sed 's,^/,,'`
+        suffix=`echo $branch|sed 's,^\(trunk\|branches\|tags\)\(.*\),\2,'` 
 	if [[ $branch = $remote_url ]]; then
 		branch=""
 	fi
@@ -41,7 +42,7 @@ function do_clone()
 				# additional options for git-svn
 				call git svn clone "$revision" "$module" "$local_directory"
 			else
-				call git svn clone "$revision" "$module" -T trunk -b $brch -t $tags "$local_directory"
+				call git svn clone "$revision" "$module" -T trunk$suffix -b $brch$suffix -t $tags$suffix "$local_directory"
 			fi
 
 		fi
@@ -49,7 +50,7 @@ function do_clone()
 			branch="$(echo ${branch}|sed 's,/$,,')"
 			if [ -n "$branch" ]; then
 				cd "$local_directory"
-				call git reset --hard $branch
+				call git reset --hard `echo $branch | sed "s,$suffix,,"`
 			fi
 		)
 	)

--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -50,7 +50,8 @@ function do_clone()
 			branch="$(echo ${branch}|sed 's,/$,,')"
 			if [ -n "$branch" ]; then
 				cd "$local_directory"
-				call git reset --hard `echo $branch | sed "s,$suffix,,"`
+				branchbase=`echo $branch | sed "s,$suffix,,"`
+				call git reset --hard $branchbase
 			fi
 		)
 	)

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-for dir in *; do
+for dir in `find .git_externals/ -name .git -type d -exec dirname {} \;`; do
     if [ -d $dir ]; then
-	cd $dir
+	pushd $dir
 	echo $dir
 	git svn fetch
 	git svn rebase
-	cd ..
+	popd
     fi
 done

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for dir in `find .git_externals/ -name .git -type d -exec dirname {} \;`; do
+for dir in `find . -regex "./.*/.*.git" -type d -exec dirname {} \;`; do
     if [ -d $dir ]; then
 	pushd $dir
 	echo $dir


### PR DESCRIPTION
Hi,

When executing your script on the following svn url : https://svn.bestofmedia.com/frontend-repository/frontendCommons/sWebserviceClientGenerator/trunk/lib/bomLibrairies

the script looses track because the sed expression deletes the "trunk" part instead of getting the part before "trunk". Here is a echo of the commande that is executed :
- call git svn clone '' https://svn.bestofmedia.com/frontend-repository/frontendCommons/sWebserviceClientGenerator/lib/bomLibrairies -T trunk -b branches -t tags lib/bomLibrairies

But also in the svn clone we should rather do something like 
git svn clone https://svn.bestofmedia.com/frontend-repository/frontendCommons/sWebserviceClientGenerator -T trunk/lib/bomLibraries -b branches/lib/bomLibraries -t tags/lib/bomLibraries lib/bomLibrairies

No? Anyway that is the fix I'm submitting. Please tell me what you think

Johan
