### PR TITLE
makes tokenizing git-svn show-externals output more reliable

### DIFF
--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -96,7 +96,8 @@ function is_excluded()
 }
 
 
-git svn show-externals|grep -vE '#|^$'|while read -a words
+git svn show-externals|grep -vE '#|^$'| \
+	sed 's/\(-r\)[ ]*\([0-9]\{1,\}\)/\1\2/'|while read -a words
 do
 	[ -z "${words[*]}" ] && continue
 

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-for dir in *; do
+toplevel_directory="$(git rev-parse --show-cdup)"
+[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
+
+find .git_externals -type d -name .git | while read gitdir; do
+	dir=$(dirname "$gitdir")
     if [ -d $dir ]; then
-	cd $dir
+	pushd $dir
 	echo $dir
 	git svn fetch
 	git svn rebase
-	cd ..
+	popd
     fi
 done


### PR DESCRIPTION
Sometimes show-externals will output a space between the -r and
<revision>. This patch removes that space.
