### PR TITLE
Fix for #11, Added Support for Custom Destination Names

### DIFF
--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -97,11 +97,11 @@ function is_excluded()
 
 
 git svn show-externals|grep -vE '#|^$'| \
-	sed 's/\(-r\)[ ]*\([0-9]\{1,\}\)/\1\2/'|while read -a words
+	sed 's/\([a-zA-Z_\.\-]*\)[ ]*\(-r\)[ ]*\([0-9]\{1,\}\)/\1 \2\3/'|while read -a words
 do
 	[ -z "${words[*]}" ] && continue
 
-	local_directory="$(echo ${words[0]}|sed 's,^/,,')"
+	local_directory="$(echo ${words[0]}${words[3]}|sed 's,^/,,')"
 	revision=""
 	remote_url="${words[1]}"
 

--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -97,7 +97,7 @@ function is_excluded()
 
 
 git svn show-externals|grep -vE '#|^$'| \
-	sed 's/\([a-zA-Z_\.\-]*\)[ ]*\(-r\)[ ]*\([0-9]\{1,\}\)/\1 \2\3/'|while read -a words
+	sed 's/\(\S*\)\s*\(-r\)\s*\([0-9]\{1,\}\)/\1 \2\3/'|while read -a words
 do
 	[ -z "${words[*]}" ] && continue
 


### PR DESCRIPTION
Hi,

the script did not work for me as is because for whatever reason `git svn show-externals` did not separate the revision and the path in my setting.

In addition, my externals specified a customized name so this needed a little tweaking, too.

Both changes are actually contained within the first commit, but the regexp will fail for directory names that end in a non-ASCII-character.
This is rectified in the second commit which uses the (non-)whitespace-character-distinction to capture the path and revision.
