### PR TITLE
Multiple changes for windows & relative path support

### DIFF
--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -5,6 +5,13 @@ set -e
 toplevel_directory="$(git rev-parse --show-cdup)"
 [ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
 
+function isWindows() { [[ -n "$WINDIR" ]]; }
+
+if isWindows; then
+    if ! net session &> /dev/null; then
+        echo 'Please run as administrator! It is required to create symbolic links.'; exit 1;
+    fi
+fi
 
 function call()
 {
@@ -14,61 +21,69 @@ function call()
     return "$?"
 }
 
+
 function do_clone()
 {
     test -d .git_externals || return 1
-    module=`echo $remote_url|sed 's,\(.*\)\(/trunk\|/branch.*\|/tag.*\),\1,'`
-    branch=`echo $remote_url|sed 's,\(.*\)\(/trunk\|/branch.*\|/tag.*\),\2,'|sed 's,^/,,'`
-    if [[ $branch = $remote_url ]]; then
-        branch=""
-    fi
-     (
-        cd .git_externals
-        if [ -d "$local_directory" ]; then
-            (
-                cd "$local_directory"
-                call git svn fetch --all
-            )
-        else
-            tags="tags"
-            brch="branches"
-            branchpath=$(echo $branch|cut -f1 -d/)
-            echo $tags|grep $branchpath >/dev/null 2>&1 && tags=$branchpath
-            echo $brch|grep $branchpath >/dev/null 2>&1 && brch=$branchpath
+    
+    cd .git_externals
 
-            if [ "$module" = "$remote_url" ]; then
-                # URL does not contains any trunk, branches or tags part, so we dont need
-                # additional options for git-svn
-                call git svn clone "$revision" "$module" "$local_directory"
-            else
-                call git svn clone "$revision" "$module" -T trunk -b $brch -t $tags "$local_directory"
-            fi
+    #Scape spaces in the path with backslash
+    destination_scaped="$(echo ${destination} | sed -E 's/ /\\ /g')" 
 
-        fi
+    #Replace spaces in the url by %20
+    remote_url_no_spaces="$(echo ${remote_url} | sed -r 's_ _%20_g')"
+
+    echo "External destination $destination" 
+    if [ -d "$destination" ]; then
         (
-            branch="$(echo ${branch}|sed 's,/$,,')"
-            if [ -n "$branch" ]; then
-                cd "$local_directory"
-                call git reset --hard $branch
-            fi
+            echo "fetching all ... " $destination 
+            cd "$destination"
+            call git svn fetch --all
         )
-    )
+    else
+        
+        call git svn clone -r" ${revision}" "$remote_url_no_spaces" "$destination_scaped"
+    fi
+    
 }
 
 function do_link()
 {
+    
     dir="$1"
-    base="$(dirname $dir)"
+    
+    #Return to the top level directory
+    top=$(git rev-parse --show-cdup)
+    cd "$top" 
+
+    base=$(dirname "$dir")
     (
         mkdir -p "$base"
-        cd $base
-        rel=$(git rev-parse --show-cdup)
-        ln -sf ${rel}.git_externals/"$dir"
+        cd "$base"
+        destFolder=$(basename "$dir")
+        
+        if [[ -d "$destFolder" ]] || [[ -L "$destFolder" ]]; then
+            rm -rf "$destFolder"     
+        fi
+
+        top=$(git rev-parse --show-cdup)
+
+        if isWindows; then
+            link_des_windows=$(cygpath -w "${top}.git_externals/${dir}")
+            cmd <<< "mklink /D \"${destFolder%/}\" \"${link_des_windows%/}\"" > /dev/null
+        else
+            ln -s "${top}.git_externals/${dir}" "$destFolder"
+        fi
     )
 }
 
 function do_excludes()
 {
+     #Return to the top level directory
+    top=$(git rev-parse --show-cdup)
+    cd "$top"
+
     dir="$1"
     git_excludes_path=.git/info/exclude
     if ! grep -q '^.git_externals$' "$git_excludes_path"
@@ -100,24 +115,65 @@ git svn show-externals | grep -vE '#|^$' | \
     sed 's/\(-r\)[ ]*\([0-9]\{1,\}\)/\1\2/' | \
     while read svn_externals
 do
+    echo $svn_externals
+        
+    # First get the local directory in which the external was defined
+    local_directory="$(echo ${svn_externals} | sed -r 's_\/(\.\.|\^|)\/.*__' )" 
+    
+    echo "Local directory ${local_directory}"
 
-    number_fields="$(echo ${svn_externals}|awk '{print NF}')"
+    # Now remove the local directory from the line and see what else we have
+    local_directory_scaped="$(echo ${local_directory} | sed -r 's_\/_\\/_g')" 
+    if [ -n "${local_directory_scaped}" ] ; then
+        otherArguments="$(echo ${svn_externals} | sed -r "s_${local_directory_scaped}__")" 
+    else
+        otherArguments="${svn_externals}" 
+    fi
+    
+    number_fields="$(echo ${otherArguments}|awk '{print NF}')"
     case $number_fields in
         2)
-            local_directory="$(echo ${svn_externals} | awk '{print $1}' | sed 's,^/,,')"
             revision=""
-            remote_url="$(echo ${svn_externals} | awk '{print $2}')"
+            remote_url="$(echo ${otherArguments} | awk '{print $1}')"
+            local_folder="$(echo ${otherArguments} | awk '{print $2}')"
             ;;
         3)
-            local_directory="$(echo ${svn_externals} | awk '{print $1}' | sed 's,^/,,')"
-            revision=""$(echo ${svn_externals} | awk '{print $2}')
-            remote_url="$(echo ${svn_externals} | awk '{print $3}')"
+            revision=""$(echo ${otherArguments} | awk '{print $3}')
+            remote_url="$(echo ${otherArguments} | awk '{print $1}')"
+            local_folder="$(echo ${otherArguments} | awk '{print $2}')"
             ;;
         *) continue ;;
     esac
+    
+    echo "Preprocessed remote ${remote_url}"
 
-    check_excluded=$(is_excluded $local_directory)
+    destination=".${local_directory}/${local_folder}"
+    
+    check_excluded=$(is_excluded $destination)
     if [ $check_excluded -eq 0 ] ; then
+	
+        if [[ $remote_url == /../* ]]; then
+            # We have relative paths in the remote Url.
+            # Get rid of them using readlink 
+            base_url=$(git svn info | grep 'URL: ' | sed -r 's_URL: __')
+            canonicalPath=$(readlink -m "$local_directory$remote_url")
+            remote_url=$base_url$canonicalPath
+        fi
+
+        if [[ $remote_url == //* ]]; then
+            #  In this case the path relates to the same server
+            root_url=$(git svn info | grep 'Repository Root: ' | sed -r 's_Repository Root: __')
+            svn_server=$(echo $root_url | awk -F/ '{print $3}')
+            protocol=$(echo $root_url | awk -F/ '{print $1}')
+            remote_url=${protocol}//${svn_server}${remote_url}
+        fi
+
+        if [[ $remote_url == /^/* ]]; then
+            root_url=$(git svn info | grep 'Repository Root: ' | sed -r 's_Repository Root: __')
+            remote_url=$(echo $remote_url | sed -r 's_\^/__')
+            remote_url=${root_url}${remote_url}
+        fi
+
         if [ -n "$USE_SSH" ]; then
             echo "Rewriting url to use SVN+SSH."
             shopt -s extglob
@@ -126,16 +182,20 @@ do
 
         [ -z "${remote_url}" ] && continue
 
+        if [ -n $revision ]; then
+            revision="HEAD"
+        fi
+
+
         export local_directory revision remote_url
+	
+        echo "DESTINATION: $destination -> REVISION: $revision -> REMOTE URL: $remote_url"
 
-        echo "$local_directory -> $remote_url"
-
-        dir=`dirname $local_directory`
+        dir=`dirname $destination`
         [ -d ".git_externals/$dir" ] || mkdir -p ".git_externals/$dir"
-
-        do_clone "$revision" "$remote_url" "$local_directory" || exit
-        do_link "$local_directory"
-        do_excludes "$local_directory"
+        do_clone "$revision" "$remote_url" "$destination" || exit
+        do_link "$destination"
+        do_excludes "$destination"
     fi
 
 done

--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-set -e
-
-toplevel_directory="$(git rev-parse --show-cdup)"
-[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
-
-function isWindows() { [[ -n "$WINDIR" ]]; }
-
-if isWindows; then
-    if ! net session &> /dev/null; then
-        echo 'Please run as administrator! It is required to create symbolic links.'; exit 1;
-    fi
-fi
-
 function call()
 {
     cmd="$@"
@@ -21,12 +8,13 @@ function call()
     return "$?"
 }
 
+source "./git-svn-externals-include"
 
 function do_clone()
 {
     test -d .git_externals || return 1
     
-    cd .git_externals
+    cd ".git_externals/$(get_branch)"
 
     #Scape spaces in the path with backslash
     destination_scaped="$(echo ${destination} | sed -E 's/ /\\ /g')" 
@@ -39,7 +27,7 @@ function do_clone()
         (
             echo "fetching all ... " $destination 
             cd "$destination"
-            call git svn fetch --all
+            call git svn fetch -r HEAD
         )
     else
         
@@ -48,43 +36,15 @@ function do_clone()
     
 }
 
-function do_link()
-{
-    
-    dir="$1"
-    
-    #Return to the top level directory
-    top=$(git rev-parse --show-cdup)
-    cd "$top" 
-
-    base=$(dirname "$dir")
-    (
-        mkdir -p "$base"
-        cd "$base"
-        destFolder=$(basename "$dir")
-        
-        if [[ -d "$destFolder" ]] || [[ -L "$destFolder" ]]; then
-            rm -rf "$destFolder"     
-        fi
-
-        top=$(git rev-parse --show-cdup)
-
-        if isWindows; then
-            link_des_windows=$(cygpath -w "${top}.git_externals/${dir}")
-            cmd <<< "mklink /D \"${destFolder%/}\" \"${link_des_windows%/}\"" > /dev/null
-        else
-            ln -s "${top}.git_externals/${dir}" "$destFolder"
-        fi
-    )
-}
-
 function do_excludes()
 {
-     #Return to the top level directory
+    #Return to the top level directory
     top=$(git rev-parse --show-cdup)
     cd "$top"
 
-    dir="$1"
+    #Scape spaces in the path with backslash and remove the firt dot and slash
+    dir=$(echo "${1}" | sed -E 's/ /\\ /g' | sed s_^\.\/__) 
+    echo "Excluding $dir"
     git_excludes_path=.git/info/exclude
     if ! grep -q '^.git_externals$' "$git_excludes_path"
     then
@@ -110,92 +70,110 @@ function is_excluded()
     return
 }
 
+function git_svn_clone_externals()
+{
+	set -e
 
-git svn show-externals | grep -vE '#|^$' | \
-    sed 's/\(-r\)[ ]*\([0-9]\{1,\}\)/\1\2/' | \
-    while read svn_externals
-do
-    echo $svn_externals
-        
-    # First get the local directory in which the external was defined
-    local_directory="$(echo ${svn_externals} | sed -r 's_\/(\.\.|\^|)\/.*__' )" 
-    
-    echo "Local directory ${local_directory}"
+	toplevel_directory="$(git rev-parse --show-cdup)"
+	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
 
-    # Now remove the local directory from the line and see what else we have
-    local_directory_scaped="$(echo ${local_directory} | sed -r 's_\/_\\/_g')" 
-    if [ -n "${local_directory_scaped}" ] ; then
-        otherArguments="$(echo ${svn_externals} | sed -r "s_${local_directory_scaped}__")" 
-    else
-        otherArguments="${svn_externals}" 
-    fi
-    
-    number_fields="$(echo ${otherArguments}|awk '{print NF}')"
-    case $number_fields in
-        2)
-            revision=""
-            remote_url="$(echo ${otherArguments} | awk '{print $1}')"
-            local_folder="$(echo ${otherArguments} | awk '{print $2}')"
-            ;;
-        3)
-            revision=""$(echo ${otherArguments} | awk '{print $3}')
-            remote_url="$(echo ${otherArguments} | awk '{print $1}')"
-            local_folder="$(echo ${otherArguments} | awk '{print $2}')"
-            ;;
-        *) continue ;;
-    esac
-    
-    echo "Preprocessed remote ${remote_url}"
+	if isWindows; then
+	    if ! net session &> /dev/null; then
+	        echo 'Please run as administrator! It is required to create symbolic links.'; exit 1;
+	    fi
+	fi
 
-    destination=".${local_directory}/${local_folder}"
-    
-    check_excluded=$(is_excluded $destination)
-    if [ $check_excluded -eq 0 ] ; then
-	
-        if [[ $remote_url == /../* ]]; then
-            # We have relative paths in the remote Url.
-            # Get rid of them using readlink 
-            base_url=$(git svn info | grep 'URL: ' | sed -r 's_URL: __')
-            canonicalPath=$(readlink -m "$local_directory$remote_url")
-            remote_url=$base_url$canonicalPath
-        fi
+	git svn show-externals | grep -vE '#|^$' | \
+		sed 's/\(-r\)[ ]*\([0-9]\{1,\}\)/\1\2/' | \
+		while read svn_externals
+	do
+		echo $svn_externals
+			
+		# First get the local directory in which the external was defined
+		local_directory="$(echo ${svn_externals} | sed -r 's_\/(\.\.|\^|)\/.*__' )" 
+		
+		echo "Local directory ${local_directory}"
 
-        if [[ $remote_url == //* ]]; then
-            #  In this case the path relates to the same server
-            root_url=$(git svn info | grep 'Repository Root: ' | sed -r 's_Repository Root: __')
-            svn_server=$(echo $root_url | awk -F/ '{print $3}')
-            protocol=$(echo $root_url | awk -F/ '{print $1}')
-            remote_url=${protocol}//${svn_server}${remote_url}
-        fi
+		# Now remove the local directory from the line and see what else we have
+		local_directory_scaped="$(echo ${local_directory} | sed -r 's_\/_\\/_g')" 
+		if [ -n "${local_directory_scaped}" ] ; then
+			otherArguments="$(echo ${svn_externals} | sed -r "s_${local_directory_scaped}__")" 
+		else
+			otherArguments="${svn_externals}" 
+		fi
+		
+		number_fields="$(echo ${otherArguments}|awk '{print NF}')"
+		case $number_fields in
+			2)
+				revision=""
+				remote_url="$(echo ${otherArguments} | awk '{print $1}')"
+				local_folder="$(echo ${otherArguments} | awk '{print $2}')"
+				;;
+			3)
+				revision=""$(echo ${otherArguments} | awk '{print $3}')
+				remote_url="$(echo ${otherArguments} | awk '{print $1}')"
+				local_folder="$(echo ${otherArguments} | awk '{print $2}')"
+				;;
+			*) continue ;;
+		esac
+		
+		echo "Preprocessed remote ${remote_url}"
 
-        if [[ $remote_url == /^/* ]]; then
-            root_url=$(git svn info | grep 'Repository Root: ' | sed -r 's_Repository Root: __')
-            remote_url=$(echo $remote_url | sed -r 's_\^/__')
-            remote_url=${root_url}${remote_url}
-        fi
+		destination=".${local_directory}/${local_folder}"
+		
+		check_excluded=$(is_excluded $destination)
+		if [ $check_excluded -eq 0 ] ; then
+		
+			if [[ $remote_url == /../* ]]; then
+				# We have relative paths in the remote Url.
+				# Get rid of them using readlink 
+				base_url=$(git svn info | grep 'URL: ' | sed -r 's_URL: __')
+				canonicalPath=$(readlink -m "$local_directory$remote_url")
+				remote_url=$base_url$canonicalPath
+			fi
 
-        if [ -n "$USE_SSH" ]; then
-            echo "Rewriting url to use SVN+SSH."
-            shopt -s extglob
-            remote_url="${remote_url/+(http|https)/svn+ssh}"
-        fi
+			if [[ $remote_url == //* ]]; then
+				#  In this case the path relates to the same server
+				root_url=$(git svn info | grep 'Repository Root: ' | sed -r 's_Repository Root: __')
+				svn_server=$(echo $root_url | awk -F/ '{print $3}')
+				protocol=$(echo $root_url | awk -F/ '{print $1}')
+				remote_url=${protocol}//${svn_server}${remote_url}
+			fi
 
-        [ -z "${remote_url}" ] && continue
+			if [[ $remote_url == /^/* ]]; then
+				root_url=$(git svn info | grep 'Repository Root: ' | sed -r 's_Repository Root: __')
+				remote_url=$(echo $remote_url | sed -r 's_\^/__')
+				remote_url=${root_url}${remote_url}
+			fi
 
-        if [ -n $revision ]; then
-            revision="HEAD"
-        fi
+			if [ -n "$USE_SSH" ]; then
+				echo "Rewriting url to use SVN+SSH."
+				shopt -s extglob
+				remote_url="${remote_url/+(http|https)/svn+ssh}"
+			fi
+
+			[ -z "${remote_url}" ] && continue
+
+			if [ -n $revision ]; then
+				revision="HEAD"
+			fi
 
 
-        export local_directory revision remote_url
-	
-        echo "DESTINATION: $destination -> REVISION: $revision -> REMOTE URL: $remote_url"
+			export local_directory revision remote_url
+		
+			echo "DESTINATION: $destination -> REVISION: $revision -> REMOTE URL: $remote_url"
 
-        dir=`dirname $destination`
-        [ -d ".git_externals/$dir" ] || mkdir -p ".git_externals/$dir"
-        do_clone "$revision" "$remote_url" "$destination" || exit
-        do_link "$destination"
-        do_excludes "$destination"
-    fi
+			dir=`dirname $destination`
+			branch=$(get_branch)
+			[ -d ".git_externals/${branch}/$dir" ] || mkdir -p ".git_externals/${branch}/$dir"
+			echo "Cloning.............................."
+			do_clone "$revision" "$remote_url" "$destination" || exit
+			echo "Linking.............................."
+			do_link "$destination"
+			echo "Excludes............................."
+			do_excludes "$destination"
+			echo "Next item............................"
+		fi
 
-done
+	done
+}

--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -8,8 +8,6 @@ function call()
     return "$?"
 }
 
-source "./git-svn-externals-include"
-
 function do_clone()
 {
     test -d .git_externals || return 1

--- a/git-svn-clone-externals
+++ b/git-svn-clone-externals
@@ -73,11 +73,11 @@ function git_svn_clone_externals()
 	set -e
 
 	toplevel_directory="$(git rev-parse --show-cdup)"
-	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
+	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; return; }
 
 	if isWindows; then
 	    if ! net session &> /dev/null; then
-	        echo 'Please run as administrator! It is required to create symbolic links.'; exit 1;
+	        echo 'Please run as administrator! It is required to create symbolic links.'; return;
 	    fi
 	fi
 
@@ -165,7 +165,7 @@ function git_svn_clone_externals()
 			branch=$(get_branch)
 			[ -d ".git_externals/${branch}/$dir" ] || mkdir -p ".git_externals/${branch}/$dir"
 			echo "Cloning.............................."
-			do_clone "$revision" "$remote_url" "$destination" || exit
+			do_clone "$revision" "$remote_url" "$destination" || return
 			echo "Linking.............................."
 			do_link "$destination"
 			echo "Excludes............................."

--- a/git-svn-externals-include
+++ b/git-svn-externals-include
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+function isWindows() { [[ -n "$WINDIR" ]]; }
+
+function get_branch()
+{
+    top=$(git rev-parse --show-cdup) 
+    pushd "$top" &> /dev/null
+
+    echo $(git svn info | grep "URL" | sed  "s_URL: __" | awk -F "/" '{print $NF}')
+
+    popd &> /dev/null
+}
+
+function do_link()
+{
+    
+    dir="$1"
+    
+    #Return to the top level directory
+    top=$(git rev-parse --show-cdup)
+    cd "$top" 
+
+     if git ls-files "$dir" --error-unmatch &> /dev/null; then 
+        # If the folder is tracked, we want to exit...
+        #echo "File ${dir} tracked... doing nothing"
+        return;
+    fi;
+
+    base=$(dirname "$dir")
+    (
+        mkdir -p "$base"
+        cd "$base"
+        destFolder=$(basename "$dir")
+        
+        if [[ -d "$destFolder" ]] || [[ -L "$destFolder" ]]; then
+            #echo "Removing link ${destFolder}"
+            rm -rf "$destFolder"     
+        fi
+
+        top=$(git rev-parse --show-cdup)
+        #echo "Top directory is $top"
+        #echo "Current dir is is $PWD"
+
+        if isWindows; then
+            link_des_windows=$(cygpath -w "${top}.git_externals/$(get_branch)/${dir}")
+            
+            #echo "Creating link from ${PWD}/${destFolder} to $link_des_windows"
+            cmd <<< "mklink /D \"${destFolder%/}\" \"${link_des_windows%/}\"" > /dev/null
+            
+        else
+            ln -s "${top}.git_externals/$(get_branch)${dir}" "$destFolder"
+        fi
+    )
+}

--- a/git-svn-externals-link
+++ b/git-svn-externals-link
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-source "./git-svn-externals-include"
-
-function git-svn-externals-link()
+function git_svn_externals_link()
 {
 	toplevel_directory="$(git rev-parse --show-cdup)"
 	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
 
 	echo "Creating symbolic links for externals"
+	externals=.git_externals/$(get_branch)
 
-	find .git_externals -type d -name .git | while read gitdir; do
-		dir=$(dirname "$gitdir" | sed 's|.git_externals/||' )
-		
+	find "$externals" -type d -name .git | while read gitdir; do
+		dir=$(dirname "$gitdir" | sed "s|${externals}/||" )
+		echo "Doing links on $dir"		
 		do_link "$dir"
 	done
 

--- a/git-svn-externals-link
+++ b/git-svn-externals-link
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source "./git-svn-externals-include"
+
+function git-svn-externals-link()
+{
+	toplevel_directory="$(git rev-parse --show-cdup)"
+	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
+
+	echo "Creating symbolic links for externals"
+
+	find .git_externals -type d -name .git | while read gitdir; do
+		dir=$(dirname "$gitdir" | sed 's|.git_externals/||' )
+		
+		do_link "$dir"
+	done
+
+	echo "Finished creating symbolic links"
+}

--- a/git-svn-externals-link
+++ b/git-svn-externals-link
@@ -3,7 +3,7 @@
 function git_svn_externals_link()
 {
 	toplevel_directory="$(git rev-parse --show-cdup)"
-	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
+	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; return; }
 
 	echo "Creating symbolic links for externals"
 	externals=.git_externals/$(get_branch)

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function git-svn-externals-update()
+function git_svn_externals_update()
 {
 	toplevel_directory="$(git rev-parse --show-cdup)"
 	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; return; }

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -3,7 +3,7 @@
 function git-svn-externals-update()
 {
 	toplevel_directory="$(git rev-parse --show-cdup)"
-	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
+	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; return; }
 
 	find .git_externals -type d -name .git | while read gitdir; do
 		dir=$(dirname "$gitdir")

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -1,18 +1,21 @@
 #!/bin/bash
 
+function git_svn_fetch_rebase()
+{
+	dir=$(dirname "$1")
+    if [ -d "$dir" ]; then
+	echo "$dir"
+	git -C  "$dir" svn fetch -r HEAD
+	git -C  "$dir" svn rebase
+    fi
+}
+
+
 function git_svn_externals_update()
 {
 	toplevel_directory="$(git rev-parse --show-cdup)"
 	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; return; }
 
-	find .git_externals -type d -name .git | while read gitdir; do
-		dir=$(dirname "$gitdir")
-	    if [ -d $dir ]; then
-		pushd $dir
-		echo $dir
-		git svn fetch -r HEAD
-		git svn rebase
-		popd
-	    fi
-	done
+	export -f git_svn_fetch_rebase
+	find .git_externals -type d -name .git | xargs -P4 -I{} bash -c 'git_svn_fetch_rebase "$@"' _ {}
 }

--- a/git-svn-externals-update
+++ b/git-svn-externals-update
@@ -1,15 +1,18 @@
 #!/bin/bash
 
-toplevel_directory="$(git rev-parse --show-cdup)"
-[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
+function git-svn-externals-update()
+{
+	toplevel_directory="$(git rev-parse --show-cdup)"
+	[ -n "$toplevel_directory" ] && { echo "please run from the toplevel directory"; exit 1; }
 
-find .git_externals -type d -name .git | while read gitdir; do
-	dir=$(dirname "$gitdir")
-    if [ -d $dir ]; then
-	pushd $dir
-	echo $dir
-	git svn fetch
-	git svn rebase
-	popd
-    fi
-done
+	find .git_externals -type d -name .git | while read gitdir; do
+		dir=$(dirname "$gitdir")
+	    if [ -d $dir ]; then
+		pushd $dir
+		echo $dir
+		git svn fetch -r HEAD
+		git svn rebase
+		popd
+	    fi
+	done
+}


### PR DESCRIPTION
- Adding support for relative paths in externals. See link below for details:
   http://svnbook.red-bean.com/nightly/en/svn.advanced.externals.html
- Adding support for windows symbolic links. Note that "ln" does NOT work in git bash (just copies the files).
- Simplifying the handle of external git repositories. No need to track multiple branches in the external clone.